### PR TITLE
add caseConverter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ bookshelf.plugin(plugin);
 - soft-delete
 - accessible-attributes
 
+You can pass `caseConverter: false` option to disable `case-converter`:
+
+```js
+const plugin = require('@yoctol/bookshelf-plugin');
+
+bookshelf.plugin(plugin, { caseConverter: false });
+```
+
 ### touch
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,11 @@ const accessibleAttributes = require('./plugins/accessible-attributes');
 const softDelete = require('./plugins/soft-delete');
 const touch = require('./plugins/touch');
 
-module.exports = (bookshelf, { touchMethod } = {}) => {
+module.exports = (bookshelf, { touchMethod, caseConverter = true } = {}) => {
   bookshelf.plugin('visibility');
-  bookshelf.plugin('case-converter');
+  if (caseConverter) {
+    bookshelf.plugin('case-converter');
+  }
   bookshelf.plugin('virtuals');
 
   bookshelf.plugin(softDelete);


### PR DESCRIPTION
You can pass `caseConverter: false` option to disable `case-converter`:

 ```js
bookshelf.plugin(plugin, { caseConverter: false });
```